### PR TITLE
Added NuGet package name to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tend to fail in unit tests without this library installed.
 
 **Microsoft Internal users**: See [specific guidance if consuming within the `VS` repo](doc/vs_repo.md).
 
-1. Install the NuGet package: [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStudio.Sdk.TestFramework.svg)](https://nuget.org/packages/Microsoft.VisualStudio.Sdk.TestFramework)
+1. Install the NuGet package `Microsoft.VisualStudio.Sdk.TestFramework` [![NuGet package](https://img.shields.io/nuget/v/Microsoft.VisualStudio.Sdk.TestFramework.svg)](https://nuget.org/packages/Microsoft.VisualStudio.Sdk.TestFramework)
 
 1. Make sure your unit test project generates the required binding redirects by adding these two properties to your project file:
 


### PR DESCRIPTION
Having the NuGet package name directly in the readme means you don't have to click through the link to get the name to copy and paste into Visual Studio.