### PR TITLE
Update to VS SDK 17.2 which removes the need for internal package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ tend to fail in unit tests without this library installed.
 
 **Microsoft Internal users**: See [specific guidance if consuming within the `VS` repo](doc/vs_repo.md).
 
-1. Modify/create your nuget.config file to include [these two feeds](https://github.com/microsoft/vssdktestfx/blob/5327c89b7f53afda1baa9558ad4901c4290289d2/nuget.config#L9-L10).
-   This is a workaround for a Visual Studio 2022 SDK bug that we expect to fix in a future release. See [issue #4](https://github.com/microsoft/vssdktestfx/issues/4) for more information.
-
 1. Install the NuGet package [Microsoft.VisualStudio.Sdk.TestFramework](https://nuget.org/packages/Microsoft.VisualStudio.Sdk.TestFramework),
    or for Xunit test projects, install the more specific [Microsoft.VisualStudio.Sdk.TestFramework.Xunit](https://nuget.org/packages/Microsoft.VisualStudio.Sdk.TestFramework.Xunit) package
 

--- a/nuget.config
+++ b/nuget.config
@@ -5,8 +5,8 @@
   </config>
   <packageSources>
     <clear />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="vs-impl-public" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" protocolVersion="3" />
-    <add key="vssdk-public" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" protocolVersion="3" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="vs-impl-public" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="vssdk-public" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -22,11 +22,9 @@ Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramew
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.31902.203" />
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" Version="17.0.31918.195" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.0.32112.339" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="17.0.34" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.23-alpha" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.2.0-preview-1-32124-505" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.2.0-preview-1-32124-400" />
     <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Closes #4