### PR TITLE
Fix NuGet restore warnings

### DIFF
--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Microsoft.VisualStudio.Sdk.TestFramework</RootNamespace>
     <Description>A test library to help in writing unit and integration tests for Visual Studio extensions.</Description>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Microsoft.VisualStudio.Sdk.TestFramework</RootNamespace>
     <Description>A test library to help in writing unit and integration tests for Visual Studio extensions.</Description>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Microsoft.VisualStudio.Sdk.TestFramework</RootNamespace>
     <Description>A test library to help in writing unit and integration tests for Visual Studio extensions.</Description>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Mocks/MockVsActivityLogXunitAdapter.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/Mocks/MockVsActivityLogXunitAdapter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 using Microsoft.VisualStudio.Shell.Interop;
@@ -91,3 +93,5 @@ public class MockVsActivityLogXunitAdapter : IVsActivityLog
         return VSConstants.S_OK;
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/contentFiles/MockedVS.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/contentFiles/MockedVS.cs
@@ -10,7 +10,11 @@ namespace Microsoft.VisualStudio.Sdk.TestFramework
     /// Defines the "MockedVS" xunit test collection.
     /// </summary>
     [CollectionDefinition(Collection)]
-    public class MockedVS : ICollectionFixture<GlobalServiceProvider>, ICollectionFixture<MefHostingFixture>
+    public class MockedVS :
+#if NETFRAMEWORK || WINDOWS
+        ICollectionFixture<GlobalServiceProvider>,
+#endif
+        ICollectionFixture<MefHostingFixture>
     {
         /// <summary>
         /// The name of the xunit test collection.

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/ChildServiceProvider.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/ChildServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework;
 
 /// <summary>
@@ -55,7 +57,7 @@ public class ChildServiceProvider : IServiceProvider
     }
 
     /// <inheritdoc />
-    public object GetService(Type serviceType)
+    public object? GetService(Type serviceType)
     {
         Requires.NotNull(serviceType, nameof(serviceType));
 
@@ -67,3 +69,5 @@ public class ChildServiceProvider : IServiceProvider
         return service;
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework;
 
 using System.Windows;
@@ -280,3 +282,5 @@ public class GlobalServiceProvider : IDisposable
         }
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.Sdk.TestFramework;
 
+using System.IO;
 using System.Reflection;
 using Microsoft.VisualStudio.Composition;
 

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
@@ -57,12 +57,18 @@ public class MefHosting
     {
         Requires.NotNull(assemblyNames, nameof(assemblyNames));
 
+#if NETFRAMEWORK || WINDOWS
+        JoinableTaskFactory? joinableTaskFactory = ThreadHelper.JoinableTaskFactory;
+#else
+        JoinableTaskFactory? joinableTaskFactory = null;
+#endif
+
         this.catalogAssemblyNames = ImmutableArray.CreateRange(assemblyNames);
-        this.catalog = new AsyncLazy<ComposableCatalog>(this.CreateProductCatalogAsync, ThreadHelper.JoinableTaskFactory);
-        this.configuration = new AsyncLazy<CompositionConfiguration>(this.CreateConfigurationAsync, ThreadHelper.JoinableTaskFactory);
+        this.catalog = new AsyncLazy<ComposableCatalog>(this.CreateProductCatalogAsync, joinableTaskFactory);
+        this.configuration = new AsyncLazy<CompositionConfiguration>(this.CreateConfigurationAsync, joinableTaskFactory);
         this.exportProviderFactory = new AsyncLazy<IExportProviderFactory>(
             this.CreateExportProviderFactoryAsync,
-            ThreadHelper.JoinableTaskFactory);
+            joinableTaskFactory);
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
     <Description>A test library to help in writing unit and integration tests for Visual Studio extensions.
 
 Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramework.Xunit package.</Description>
     <Product>Microsoft VisualStudio SDK Test Framework</Product>
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="System.Collections.Immutable" />
@@ -15,17 +16,11 @@ Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramew
     <Using Include="Microsoft.VisualStudio.Threading" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.53" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.2.32524.276" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.2.32524.276" />
     <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Description>A test library to help in writing unit and integration tests for Visual Studio extensions.
 
 Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramework.Xunit package.</Description>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -5,22 +5,21 @@
 
 Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramework.Xunit package.</Description>
     <Product>Microsoft VisualStudio SDK Test Framework</Product>
-    <NoWarn>$(NoWarn);NU1603</NoWarn>
-    <UseWPF>true</UseWPF>
+    <UseWPF Condition="'$(TargetFramework)'!='net6.0'">true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="System.Collections.Immutable" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="Microsoft.VisualStudio.Shell" />
-    <Using Include="Microsoft.VisualStudio.Shell.Interop" />
+    <Using Include="Microsoft.VisualStudio.Shell.Interop" Condition="'$(TargetFramework)'!='net6.0'" />
     <Using Include="Microsoft.VisualStudio.Threading" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.53" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.2.32524.276" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.2.32524.276" Condition="'$(TargetFramework)'!='net6.0'" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.2.32524.276" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="System.ComponentModel.Composition" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockAsyncServiceProvider.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockAsyncServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 /// <summary>
@@ -55,3 +57,5 @@ internal class MockAsyncServiceProvider : IAsyncServiceProvider2, Shell.Interop.
         return completionSource.Task;
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockLocalRegistry.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockLocalRegistry.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 using System.Runtime.InteropServices.ComTypes;
@@ -63,3 +65,5 @@ internal class MockLocalRegistry : ILocalRegistry
         return VSConstants.E_NOTIMPL;
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockTaskSchedulerService.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockTaskSchedulerService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 /// <summary>
@@ -78,3 +80,5 @@ internal sealed class MockTaskSchedulerService : IVsTaskSchedulerService, IVsTas
         }
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTask.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTask.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 #pragma warning disable VSTHRD002 // Our mock implementation is pretty cheap
@@ -163,3 +165,5 @@ internal sealed class MockVSTask : IVsTask, IVsTaskJoinableTask, IVsTaskEvents, 
         this.OnMarkedAsBlocking?.Invoke(this, new BlockingTaskEventArgs(this, this));
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTaskCompletionSource.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTaskCompletionSource.cs
@@ -58,7 +58,7 @@ internal sealed class MockVSTaskCompletionSource : IVsTaskCompletionSource
     public void SetCanceled() => this.UnderlyingTask.Cancel();
 
     /// <inheritdoc />
-    public void SetFaulted(int hr) => this.taskCompletionSource.SetException(Marshal.GetExceptionForHR(hr));
+    public void SetFaulted(int hr) => this.taskCompletionSource.SetException(Marshal.GetExceptionForHR(hr) ?? new COMException("Unknown failure.", hr));
 
     /// <inheritdoc />
     public void SetResult(object result) => this.taskCompletionSource.SetResult(result);

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTaskCompletionSource.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVSTaskCompletionSource.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 /// <summary>
@@ -63,3 +65,5 @@ internal sealed class MockVSTaskCompletionSource : IVsTaskCompletionSource
     /// <inheritdoc />
     public void SetResult(object result) => this.taskCompletionSource.SetResult(result);
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVsActivityLog.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockVsActivityLog.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 namespace Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 // This interface is actually free-threaded.
@@ -79,3 +81,5 @@ public class MockVsActivityLog : IVsActivityLog
             : VSConstants.S_OK;
     }
 }
+
+#endif

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Strings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Sdk.TestFramework {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/ChildServiceProviderTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/ChildServiceProviderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 using Moq;
 
 public class ChildServiceProviderTests
@@ -30,3 +32,5 @@ public class ChildServiceProviderTests
         Assert.IsAssignableFrom<IVsSolution>(childServiceProvider.GetService(typeof(SVsSolution)));
     }
 }
+
+#endif

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <RootNamespace />
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0;net6.0-windows</TargetFrameworks>
     <RootNamespace />
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.Sdk.TestFramework" />
     <Using Include="Microsoft.VisualStudio.Shell" />
-    <Using Include="Microsoft.VisualStudio.Shell.Interop" />
+    <Using Include="Microsoft.VisualStudio.Shell.Interop" Condition="'$(TargetFramework)'!='net6.0'" />
     <Using Include="Microsoft.VisualStudio.Threading" />
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/TestFrameworkTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/TestFrameworkTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 using System.Runtime.InteropServices;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
@@ -302,3 +304,5 @@ public class TestFrameworkTests : LoggingTestBase
         public void Throw() => throw new InvalidOperationException("Test");
     }
 }
+
+#endif

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/VsActivityLogTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/VsActivityLogTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || WINDOWS
+
 using Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 
 [Collection(MockedVS.Collection)]
@@ -81,3 +83,5 @@ public class VsActivityLogTests
         }
     }
 }
+
+#endif


### PR DESCRIPTION
With this test framework's recent addition of brokered service testing, which may apply on non-Windows platforms, we should enable test projects to reference this while targeting .NET 6 without nuget restore warnings.