### PR TITLE
Remove MEF filtering out of MS.VS.Utilities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,8 +11,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.5.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.4.33216.74" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.4.33216.74" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.0-preview-2-33413-016" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.6.0-preview-2-33413-016" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.2.46-beta" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="7.0.0" />

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/MefHosting.cs
@@ -122,12 +122,6 @@ public class MefHosting
                 continue;
             }
 
-            if (string.Equals(Path.GetFileNameWithoutExtension(file), "Microsoft.VisualStudio.Utilities", StringComparison.OrdinalIgnoreCase))
-            {
-                // Temporarily skip MS.VS.Utilities till it removes the MEF parts that are redundant with those from Microsoft.ServiceHub.Framework.
-                continue;
-            }
-
             string? assemblyFullName = null;
             try
             {


### PR DESCRIPTION
This filter was temporarily added while MS.VS.Utilities and the OSS fork of MS.SH.Framework both contained the same MEF parts. Since then, MS.VS.Utilities has been updated and a new package published without those redundant parts, so it is once again desirable to allow its inclusion in the MEF catalog.