### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,12 +19,12 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# Xml project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,msbuildproj}]
+# MSBuild project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,msbuildproj,props,targets}]
 indent_size = 2
 
 # Xml config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct,runsettings}]
+[*.{ruleset,config,nuspec,resx,vsixmanifest,vsct,runsettings}]
 indent_size = 2
 
 # JSON files

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,9 @@
 *.sh eol=lf
 *.ps1 eol=lf
 
+# The macOS codesign tool is extremely picky, and requires LF line endings.
+*.plist eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 
 # dotnet tool local install directory
 .store/
+
+# mac-created file to track user view preferences for a directory
+.DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,7 +11,8 @@
     "davidanson.vscode-markdownlint",
     "dotjoshjohnson.xml",
     "ms-vscode-remote.remote-containers",
-    "ms-azuretools.vscode-docker"
+    "ms-azuretools.vscode-docker",
+    "tintoy.msbuild-project-tools"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,7 @@
     <!-- Local builds should embed PDBs so we never lose them when a subsequent build occurs. -->
     <DebugType Condition=" '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">embedded</DebugType>
 
+    <PackageProjectUrl>https://github.com/microsoft/vssdktestfx</PackageProjectUrl>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -53,7 +54,7 @@
 
   <Target Name="PrepareReleaseNotes" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
     <PropertyGroup>
-      <PackageReleaseNotes>https://github.com/microsoft/vssdktestfx/releases/tag/v$(Version)</PackageReleaseNotes>
+      <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.93</MicroBuildVersion>
+    <MicroBuildVersion>2.0.113</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0-release-20221220-01" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.5.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.0-preview-2-33413-016" />
@@ -29,7 +29,7 @@
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
   </ItemGroup>
   <ItemGroup>
-    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" /> -->
+    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" /> -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -116,11 +116,10 @@ if (!$OwnerAlias) {
     if ($env:BUILD_REQUESTEDFOREMAIL) {
         Write-Verbose 'Using $env:BUILD_REQUESTEDFOREMAIL and slicing to just the alias for OwnerAlias.'
         $OwnerAlias = ($env:BUILD_REQUESTEDFOREMAIL -split '@')[0]
+    } else {
+        $OwnerAlias = $TeamAlias
     }
-    else {
-        Write-Verbose 'Using $env:USERNAME for OwnerAlias.'
-        $OwnerAlias = $env:USERNAME
-    }
+
     if (!$OwnerAlias) {
         Write-Error "Unable to determine default value for -OwnerAlias."
     }

--- a/azure-pipelines/Get-NuGetTool.ps1
+++ b/azure-pipelines/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
     [Parameter()]
-    [string]$NuGetVersion='5.2.0'
+    [string]$NuGetVersion='6.4.0'
 )
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"

--- a/azure-pipelines/Merge-CodeCoverage.ps1
+++ b/azure-pipelines/Merge-CodeCoverage.ps1
@@ -41,7 +41,7 @@ if ($reports) {
 
     $Inputs = $reports |% { Resolve-Path -relative $_.FullName }
 
-    if (Split-Path $OutputFile) {
+    if ((Split-Path $OutputFile) -and -not (Test-Path (Split-Path $OutputFile))) {
         New-Item -Type Directory -Path (Split-Path $OutputFile) | Out-Null
     }
 

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -8,6 +8,7 @@ steps:
   inputs:
     TargetFolders: |
       $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)/NuGet
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: MicroBuildCleanup@1
   condition: succeededOrFailed()
@@ -23,7 +24,7 @@ steps:
       /repoName:$(Build.Repository.Name)
       /additionalCodexArguments:-bld
       /additionalCodexArguments:$(Build.ArtifactStagingDirectory)/build_logs
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Agent.OS'], 'Windows_NT'))
   continueOnError: true
 
 - ${{ if eq(parameters.EnableCompliance, 'true') }}:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -7,12 +7,15 @@ steps:
   inputs:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: MicroBuildSigningPlugin@3
   inputs:
     signType: $(SignType)
     zipSources: false
   displayName: 🔧 Install MicroBuild Signing Plugin
+  condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['SignType'], 'real')))
 
 - task: MicroBuildSbomPlugin@1
   displayName: 🔧 Install MicroBuild Sbom Plugin
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -42,7 +42,7 @@ stages:
 
 - stage: Build
   variables:
-    TreatWarningsAsErrors: true
+    MSBuildTreatWarningsAsErrors: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     BuildConfiguration: Release
     NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -9,17 +9,14 @@ stages:
     - checkout: none
     - download: current
       artifact: Variables-Windows
-      displayName: Download Variables-Windows artifact
-    - task: PowerShell@2
-      displayName: Set pipeline variables based on artifacts
-      inputs:
-        targetType: filePath
-        filePath: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: 🔻 Download Variables-Windows artifact
+    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: ⚙️ Set pipeline variables based on artifacts
     - download: current
       artifact: symbols-legacy
-      displayName: Download symbols-legacy artifact
+      displayName: 🔻 Download symbols-legacy artifact
     - task: MicroBuildArchiveSymbols@1
-      displayName: Archive symbols to Symweb
+      displayName: 🔣 Archive symbols to Symweb
       inputs:
         SymbolsFeatureName: $(SymbolsFeatureName)
         SymbolsSymwebProject: VS
@@ -27,7 +24,7 @@ stages:
         SymbolsEmailContacts: vsidemicrobuild
         SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
     - task: MicroBuildCleanup@1
-      displayName: Send Telemetry
+      displayName: ☎️ Send Telemetry
 
 - stage: azure_public_vssdk_feed
   displayName: azure-public/vssdk feed
@@ -41,16 +38,16 @@ stages:
     - checkout: none
     - download: current
       artifact: deployables-Windows
-      displayName: Download deployables-Windows artifact
+      displayName: 🔻 Download deployables-Windows artifact
     - task: UseDotNet@2
-      displayName: Install .NET SDK
+      displayName: ⚙️ Install .NET SDK
       inputs:
         packageType: sdk
         version: 6.x
     - task: NuGetAuthenticate@1
-      displayName: Authenticate NuGet feeds
+      displayName: 🔏 Authenticate NuGet feeds
       inputs:
         nuGetServiceConnections: azure-public/vssdk
         forceReinstallCredentialProvider: true
     - script: dotnet nuget push $(Pipeline.Workspace)/deployables-Windows/NuGet/*.nupkg -s https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json --api-key azdo --skip-duplicate
-      displayName: Push nuget packages
+      displayName: 📦 Push nuget packages

--- a/azure-pipelines/release-deployment-prep.yml
+++ b/azure-pipelines/release-deployment-prep.yml
@@ -1,9 +1,6 @@
 steps:
 - download: CI
   artifact: Variables-Windows
-  displayName: Download Variables-Windows artifact
-- task: PowerShell@2
-  displayName: Set pipeline variables based on artifacts
-  inputs:
-    targetType: filePath
-    filePath: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
+  displayName: 🔻 Download Variables-Windows artifact
+- powershell: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
+  displayName: ⚙️ Set pipeline variables based on artifacts

--- a/azure-pipelines/test.runsettings
+++ b/azure-pipelines/test.runsettings
@@ -36,8 +36,6 @@
             <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
             <!-- When set to True, instrumented binaries on disk are removed and original files are restored. -->
             <EnableStaticNativeInstrumentationRestore>True</EnableStaticNativeInstrumentationRestore>
-            <EnableStaticManagedInstrumentation>True</EnableStaticManagedInstrumentation>
-            <EnableDynamicManagedInstrumentation>False</EnableDynamicManagedInstrumentation>
           </CodeCoverage>
         </Configuration>
       </DataCollector>

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -19,24 +19,24 @@ jobs:
   steps:
   - checkout: none
   - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-    displayName: Set pipeline name
+    displayName: ⚙️ Set pipeline name
   - task: UseDotNet@2
-    displayName: Install .NET SDK
+    displayName: ⚙️ Install .NET SDK
     inputs:
       packageType: sdk
       version: 6.x
   - task: NuGetAuthenticate@1
-    displayName: Authenticate NuGet feeds
+    displayName: 🔏 Authenticate NuGet feeds
     inputs:
       forceReinstallCredentialProvider: true
   - template: release-deployment-prep.yml
   - download: CI
     artifact: VSInsertion-Windows
-    displayName: Download VSInsertion-Windows artifact
+    displayName: 🔻 Download VSInsertion-Windows artifact
   - script: dotnet nuget push $(Pipeline.Workspace)\CI\VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-    displayName: Push CoreXT packages to VS feed
+    displayName: 📦 Push CoreXT packages to VS feed
   - task: MicroBuildInsertVsPayload@4
-    displayName: Insert VS Payload
+    displayName: 🏭 Insert VS Payload
     inputs:
       TeamName: $(TeamName)
       TeamEmail: $(TeamEmail)
@@ -45,7 +45,7 @@ jobs:
       AutoCompletePR: true
       AutoCompleteMergeStrategy: Squash
   - task: MicroBuildCleanup@1
-    displayName: Send Telemetry
+    displayName: ☎️ Send Telemetry
   - powershell: |
       $contentType = 'application/json';
       $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
@@ -54,4 +54,4 @@ jobs:
       Write-Host $request
       $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
       Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
-    displayName: Retain inserted builds
+    displayName: 🗻 Retain inserted builds

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -36,30 +36,27 @@ stages:
       clean: true
       fetchDepth: 1
     - task: UseDotNet@2
-      displayName: Install .NET SDK
+      displayName: ⚙️ Install .NET SDK
       inputs:
         packageType: sdk
         version: 6.x
     - task: NuGetAuthenticate@1
-      displayName: Authenticate NuGet feeds
+      displayName: 🔏 Authenticate NuGet feeds
       inputs:
         forceReinstallCredentialProvider: true
     - download: current
       artifact: Variables-Windows
-      displayName: Download Variables-Windows artifact
-    - task: PowerShell@2
-      displayName: Set pipeline variables based on artifacts
-      inputs:
-        targetType: filePath
-        filePath: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: 🔻 Download Variables-Windows artifact
+    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: ⚙️ Set pipeline variables based on artifacts
     - download: current
       artifact: VSInsertion-Windows
-      displayName: Download VSInsertion-Windows artifact
+      displayName: 🔻 Download VSInsertion-Windows artifact
     - script: dotnet nuget push VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-      displayName: Push CoreXT packages to VS feed
+      displayName: 📦 Push CoreXT packages to VS feed
       workingDirectory: $(Pipeline.Workspace)
     - task: MicroBuildInsertVsPayload@4
-      displayName: Insert VS Payload
+      displayName: 🏭 Insert VS Payload
       inputs:
         TeamName: $(TeamName)
         TeamEmail: $(TeamEmail)
@@ -78,7 +75,7 @@ stages:
         Remember to Abandon and (if allowed) to Delete Source Branch on that insertion PR when validation is complete.
         "@
         azure-pipelines/PostPRMessage.ps1 -AccessToken '$(System.AccessToken)' -Markdown $Markdown -Verbose
-      displayName: Comment on pull request
+      displayName: ✏️ Comment on pull request
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     - task: MicroBuildCleanup@1
-      displayName: Send Telemetry
+      displayName: ☎️ Send Telemetry

--- a/init.ps1
+++ b/init.ps1
@@ -39,6 +39,8 @@
     Install the MicroBuild SBOM plugin.
 .PARAMETER AccessToken
     An optional access token for authenticating to Azure Artifacts authenticated feeds.
+.PARAMETER Interactive
+    Runs NuGet restore in interactive mode. This can turn authentication failures into authentication challenges.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 Param (
@@ -59,7 +61,9 @@ Param (
     [Parameter()]
     [switch]$SBOM,
     [Parameter()]
-    [string]$AccessToken
+    [string]$AccessToken,
+    [Parameter()]
+    [switch]$Interactive
 )
 
 $EnvVars = @{}
@@ -91,14 +95,20 @@ try {
     $HeaderColor = 'Green'
 
     if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
+        $RestoreArguments = @()
+        if ($Interactive)
+        {
+            $RestoreArguments += '--interactive'
+        }
+
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
-        dotnet restore
+        dotnet restore @RestoreArguments
         if ($lastexitcode -ne 0) {
             throw "Failure while restoring packages."
         }
     }
 
-    $InstallNuGetPkgScriptPath = ".\azure-pipelines\Install-NuGetPackage.ps1"
+    $InstallNuGetPkgScriptPath = "$PSScriptRoot\azure-pipelines\Install-NuGetPackage.ps1"
     $nugetVerbosity = 'quiet'
     if ($Verbose) { $nugetVerbosity = 'normal' }
     $MicroBuildPackageSource = 'https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset%40Local/nuget/v3/index.json'

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -92,19 +92,18 @@ Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
 }
 
 Function Get-InstallerExe(
-    $Version,
+    [Version]$Version,
     $Architecture,
     [ValidateSet('Sdk','Runtime','WindowsDesktop')]
     [string]$sku
 ) {
     # Get the latest/actual version for the specified one
-    $TypedVersion = [Version]$Version
-    if ($TypedVersion.Build -eq -1) {
+    if ($Version.Build -eq -1) {
         $versionInfo = -Split (Invoke-WebRequest -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sku/$Version/latest.version" -UseBasicParsing)
         $Version = $versionInfo[-1]
     }
 
-    $majorMinor = "$($TypedVersion.Major).$($TypedVersion.Minor)"
+    $majorMinor = "$($Version.Major).$($Version.Minor)"
     $ReleasesFile = Join-Path $DotNetInstallScriptRoot "$majorMinor\releases.json"
     if (!(Test-Path $ReleasesFile)) {
         Get-FileFromWeb -Uri "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/$majorMinor/releases.json" -OutDir (Split-Path $ReleasesFile) | Out-Null


### PR DESCRIPTION
- Switch code coverage from static to dynamic instrumentation
- Upgrade Microsoft.CodeCoverage
- Fix merge coverage error when output directory already exists
- .gitignore .DS_Store
- Update AzureRepos package version
- Use MSBuildTreatWarningsAsErrors on official microbuild too
- Fix schedule trigger for source archival
- Increase likelihood that folks set PackageProjectUrl property
- Bump Microsoft.CodeCoverage to 17.5.0-release-20230106-01
- Bump MicroBuildVersion from 2.0.93 to 2.0.107
- Use latest NuGet.exe version (#188)
- Bump Microsoft.CodeCoverage (#189)
- Fix working directory assumption made in init
- Skip generating the NOTICE file on PR builds
- Add emojis to insertion pipeline steps
- Simplify Version cast in ps1 script
- Add more emojis and use simpler powershell task syntax
- Use LF line endings for plist files
- Add `-interactive` switch to init.ps1
- Bump MicroBuild to 2.0.112
- Remove certain tasks on non-Windows agents
- Bump dependencies to 17.5.0 versions
- Add msbuild extension for VS Code
- Drop test-tools as a nuget feed source
- Bump MicroBuild version
