### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.3",
+      "version": "7.3.4",
       "commands": [
         "pwsh"
       ]
@@ -15,13 +15,13 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.6.11",
+      "version": "17.7.0",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.5.119",
+      "version": "3.6.128",
       "commands": [
         "nbgv"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -176,5 +176,8 @@ dotnet_diagnostic.DOC108.severity = warning
 dotnet_diagnostic.DOC200.severity = warning
 dotnet_diagnostic.DOC202.severity = warning
 
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = warning
+
 [*.sln]
 indent_style = tab

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.115</MicroBuildVersion>
+    <MicroBuildVersion>2.0.117</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
@@ -22,7 +22,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.329" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
   </ItemGroup>

--- a/azure-pipelines/archive-sourcecode.yml
+++ b/azure-pipelines/archive-sourcecode.yml
@@ -34,8 +34,12 @@ steps:
   fetchDepth: 0
 - powershell: tools/Install-DotNetSdk.ps1
   displayName: ⚙ Install .NET SDK
+- task: NuGetAuthenticate@1
+  displayName: 🔏 Authenticate NuGet feeds
+  inputs:
+    forceReinstallCredentialProvider: true
 - script: dotnet tool restore
-  displayName: Restore CLI tools
+  displayName: ⚙️ Restore CLI tools
 - powershell: azure-pipelines/variables/_pipelines.ps1
   failOnStderr: true
   displayName: ⚙ Set pipeline variables based on source

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -1,30 +1,36 @@
+parameters:
+- name: ArchiveSymbols
+  type: boolean
+  default: true
+
 stages:
-- stage: symbol_archive
-  displayName: Symbol archival
-  condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
-  jobs:
-  - job: archive
-    pool: VSEng-ReleasePool-1ES
-    steps:
-    - checkout: none
-    - download: current
-      artifact: Variables-Windows
-      displayName: 🔻 Download Variables-Windows artifact
-    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
-      displayName: ⚙️ Set pipeline variables based on artifacts
-    - download: current
-      artifact: symbols-legacy
-      displayName: 🔻 Download symbols-legacy artifact
-    - task: MicroBuildArchiveSymbols@1
-      displayName: 🔣 Archive symbols to Symweb
-      inputs:
-        SymbolsFeatureName: $(SymbolsFeatureName)
-        SymbolsSymwebProject: VS
-        SymbolsUncPath: \\cpvsbuild\drops\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildId)\Symbols.Archival
-        SymbolsEmailContacts: vsidemicrobuild
-        SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
-    - task: MicroBuildCleanup@1
-      displayName: ☎️ Send Telemetry
+- ${{ if parameters.ArchiveSymbols }}:
+  - stage: symbol_archive
+    displayName: Symbol archival
+    condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
+    jobs:
+    - job: archive
+      pool: VSEng-ReleasePool-1ES
+      steps:
+      - checkout: none
+      - download: current
+        artifact: Variables-Windows
+        displayName: 🔻 Download Variables-Windows artifact
+      - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+        displayName: ⚙️ Set pipeline variables based on artifacts
+      - download: current
+        artifact: symbols-legacy
+        displayName: 🔻 Download symbols-legacy artifact
+      - task: MicroBuildArchiveSymbols@1
+        displayName: 🔣 Archive symbols to Symweb
+        inputs:
+          SymbolsFeatureName: $(SymbolsFeatureName)
+          SymbolsSymwebProject: VS
+          SymbolsUncPath: \\cpvsbuild\drops\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildId)\Symbols.Archival
+          SymbolsEmailContacts: vsidemicrobuild
+          SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
+      - task: MicroBuildCleanup@1
+        displayName: ☎️ Send Telemetry
 
 - stage: azure_public_vssdk_feed
   displayName: azure-public/vssdk feed

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -16,24 +16,27 @@ steps:
     targetArgument: $(System.DefaultWorkingDirectory)
     optionsUEPATH: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
 
-- task: BinSkim@4
-  displayName: 🔍 Run BinSkim
-  inputs:
-    InputType: Basic
-    Function: analyze
-    TargetPattern: guardianGlob
-    AnalyzeTargetGlob: $(BinSkimTargets)
-
 - task: CopyFiles@2
-  displayName: 🔍 Collect APIScan inputs
+  displayName: 📂 Collect APIScan/BinSkim inputs
   inputs:
     SourceFolder: $(Build.ArtifactStagingDirectory)/Symbols-$(Agent.JobName)
     # Exclude any patterns from the Contents (e.g. `!**/git2*`) that we have symbols for but do not need to run APIScan on.
     Contents: |
       **
       !**/arm64/**
+      !**/win-arm64/**
+      !**/linux-*/**
+      !**/osx*/**
     TargetFolder: $(Build.ArtifactStagingDirectory)/APIScanInputs
   condition: and(succeeded(), ${{ parameters.EnableAPIScan }}, ne(variables.ApiScanClientId, ''))
+
+- task: BinSkim@4
+  displayName: 🔍 Run BinSkim
+  inputs:
+    InputType: Basic
+    Function: analyze
+    TargetPattern: guardianGlob
+    AnalyzeTargetGlob: $(Build.ArtifactStagingDirectory)/APIScanInputs/**/*.dll;$(Build.ArtifactStagingDirectory)/APIScanInputs/**/*.exe
 
 - task: APIScan@2
   displayName: 🔍 Run APIScan

--- a/azure-pipelines/variables/BinSkimTargets.ps1
+++ b/azure-pipelines/variables/BinSkimTargets.ps1
@@ -1,4 +1,0 @@
-$Path = "$PSScriptRoot\..\..\bin"
-if (Test-Path $Path) {
-    [string]::join(';', (& "$PSScriptRoot\..\Get-SymbolFiles.ps1" -Path $Path))
-}

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -24,6 +24,8 @@ stages:
       RunTests: false
 
 - template: prepare-insertion-stages.yml
+  parameters:
+    ArchiveSymbols: false
 
 - stage: insertion
   displayName: VS insertion
@@ -60,7 +62,7 @@ stages:
       inputs:
         TeamName: $(TeamName)
         TeamEmail: $(TeamEmail)
-        InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch))
+        InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
         InsertionDescription: |
           This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
         CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.201",
+    "version": "7.0.203",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -161,13 +161,13 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
         (this.ClientProxy as IDisposable)?.Dispose();
 
         List<Task> tasks = new();
-        if (this.clientMxStream is object)
+        if (this.clientMxStream is not null)
         {
             tasks.Add(this.clientMxStream.DisposeAsync().AsTask());
             tasks.Add(this.clientMxStream.Completion);
         }
 
-        if (this.serviceMxStream is object)
+        if (this.serviceMxStream is not null)
         {
             tasks.Add(this.serviceMxStream.DisposeAsync().AsTask());
             tasks.Add(this.serviceMxStream.Completion);
@@ -202,6 +202,10 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// <returns>A <see cref="Task"/> that should be awaited by the test method.</returns>
     protected async Task AssertEventRaisedAsync(Action<TInterface, EventHandler> addHandler, Action<TInterface, EventHandler> removeHandler, Action<TServiceMock> triggerEvent)
     {
+        Requires.NotNull(addHandler);
+        Requires.NotNull(removeHandler);
+        Requires.NotNull(triggerEvent);
+
         var eventRaised = new TaskCompletionSource<object?>();
         EventHandler handler = (s, e) =>
         {
@@ -231,6 +235,10 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// <returns>A <see cref="Task"/> that should be awaited by the test method.</returns>
     protected async Task AssertEventRaisedAsync<TEventArgs>(Action<TInterface, EventHandler<TEventArgs>> addHandler, Action<TInterface, EventHandler<TEventArgs>> removeHandler, Action<TServiceMock> triggerEvent, Action<TEventArgs> argsAssertions)
     {
+        Requires.NotNull(addHandler);
+        Requires.NotNull(removeHandler);
+        Requires.NotNull(triggerEvent);
+
         var eventRaised = new TaskCompletionSource<object?>();
         EventHandler<TEventArgs> handler = (s, e) =>
         {

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -47,6 +47,7 @@ $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
 if (!$arch) { # Windows Powershell leaves this blank
     $arch = 'x64'
     if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { $arch = 'ARM64' }
+    if (${env:ProgramFiles(Arm)}) { $arch = 'ARM64' }
 }
 
 # Search for all .NET runtime versions referenced from MSBuild projects and arrange to install them.


### PR DESCRIPTION
- Fix ARM64 detection on Windows Powershell
- Bump up SDK and tools versions
- Skip symbol archival and checks for val-builds
- Copy the .config file when applying the template
- Upgrade `actions/checkout` GitHub action to v3
- Fix source archival pipeline nuget auth failures
- Fix and simplify BinSkim
- Elevate CA1062 for shipping code
- Bump Nerdbank.GitVersioning to 3.6.128
- Bump MicroBuild version
- Fix new warnings
