### PR TITLE
Merge latest Library.Template

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.130</MicroBuildVersion>
+
+    <MicroBuildVersion>2.0.131</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,9 +15,9 @@
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.2.102" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="7.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -31,7 +31,7 @@ jobs:
 
   - template: install-dependencies.yml
 
-  - script: dotnet tool run nbgv cloud -ca
+  - script: dotnet nbgv cloud -ca
     displayName: ⚙ Set build number
 
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:


### PR DESCRIPTION
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump MicroBuildVersion to 2.0.131
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
