### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.8.0",
+      "version": "17.8.2",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.5",
+      "version": "7.3.6",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.3",
+      "version": "17.8.0",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,10 @@ indent_size = 2
 indent_size = 2
 indent_style = space
 
+[*.ps1]
+indent_style = space
+indent_size = 4
+
 # Dotnet code style settings:
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+    - dependency-name: dotnet-format
+      versions: ["6.x", "7.x", "8.x"]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.131</MicroBuildVersion>
+    <MicroBuildVersion>2.0.134</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />


### PR DESCRIPTION
- Dependabot to ignore dotnet-format
- Set tab settings for .ps1 files
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
