### PR TITLE
Remove Moq dependency from nuget package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-
     <MicroBuildVersion>2.0.134</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -13,7 +12,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.35837" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.6.35837" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.2.102" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.ServiceHub.Framework.Testing;
 using Microsoft.VisualStudio.Sdk.TestFramework.Mocks;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
-using Moq;
 
 namespace Microsoft.VisualStudio.Sdk.TestFramework;
 

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -19,7 +19,6 @@ Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramew
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Condition="'$(TargetFramework)'!='net6.0'" />
     <PackageReference Include="Microsoft.ServiceHub.Framework.Testing" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" ExcludeAssets="compile" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/ChildServiceProviderTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/ChildServiceProviderTests.cs
@@ -3,7 +3,9 @@
 
 #if NETFRAMEWORK || WINDOWS
 
-using Moq;
+#pragma warning disable VSSDK006 // Check services exist
+
+using NSubstitute;
 
 public class ChildServiceProviderTests
 {
@@ -11,17 +13,15 @@ public class ChildServiceProviderTests
 
     public ChildServiceProviderTests()
     {
-        var parentSP = new Mock<IServiceProvider>();
-        parentSP.Setup(sp => sp.GetService(typeof(SVsSolution)))
-            .Returns(new Mock<IVsSolution>().Object);
-        this.parentServiceProvider = parentSP.Object;
+        this.parentServiceProvider = Substitute.For<IServiceProvider>();
+        _ = this.parentServiceProvider.GetService(typeof(SVsSolution)).Returns(Substitute.For<IVsSolution>());
     }
 
     [Fact]
     public void OffersOwnServices()
     {
         var childServiceProvider = new ChildServiceProvider(this.parentServiceProvider);
-        childServiceProvider.AddService(typeof(IVsProject), new Mock<IVsProject>().Object);
+        childServiceProvider.AddService(typeof(IVsProject), Substitute.For<IVsProject>());
         Assert.NotNull(childServiceProvider.GetService(typeof(IVsProject)));
     }
 

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Microsoft.VisualStudio.Sdk.TestFramework.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" ExcludeAssets="compile" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
   </ItemGroup>


### PR DESCRIPTION
It was not needed anyway for the shipping product. And our unit test dependency was minimal, so I switched us to NSubstitute.

Closes #135