### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,13 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.6",
+      "version": "7.4.0",
       "commands": [
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
-      "version": "17.8.2",
+      "version": "17.9.5",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,7 @@ indent_size = 4
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
 dotnet_style_qualification_for_field = true:warning
 dotnet_style_qualification_for_property = true:warning
 dotnet_style_qualification_for_method = true:warning

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-    - dependency-name: dotnet-format
-      versions: ["6.x", "7.x", "8.x"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
-  "dotnet.defaultSolution": "Microsoft.VisualStudio.Sdk.TestFramework.sln"
+  "editor.formatOnSave": true,
+  "[xml]": {
+    "editor.wordWrap": "off"
+  }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -5,7 +6,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
@@ -8,4 +9,6 @@
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
+
+  <Import Project="azure-pipelines\NuGetSbom.targets" Condition="'$(IsPackable)'!='false'" />
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- https://learn.microsoft.com/nuget/consume-packages/central-package-management -->
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.134</MicroBuildVersion>
+    <MicroBuildVersion>2.0.146</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.6.17" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.35837" />
@@ -14,9 +15,9 @@
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.2.102" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="7.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.6.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
@@ -27,7 +28,7 @@
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
-    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" /> -->
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" /> -->
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Install-NuGetPackage.ps1
+++ b/azure-pipelines/Install-NuGetPackage.ps1
@@ -45,7 +45,7 @@ try {
 
     if ($PSCmdlet.ShouldProcess($PackageId, 'nuget install')) {
         $p = Start-Process $nugetPath $nugetArgs -NoNewWindow -Wait -PassThru
-        if ($p.ExitCode -ne 0) { throw }
+        if ($null -ne $p.ExitCode -and $p.ExitCode -ne 0) { throw }
     }
 
     # Provide the path to the installed package directory to our caller.

--- a/azure-pipelines/NuGetSbom.targets
+++ b/azure-pipelines/NuGetSbom.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <GenerateSBOMThisProject>true</GenerateSBOMThisProject>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeSbomInNupkg</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="IncludeSbomInNupkg">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(SbomOutput)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/azure-pipelines/artifacts/_stage_all.ps1
+++ b/azure-pipelines/artifacts/_stage_all.ps1
@@ -30,6 +30,12 @@ function Create-SymbolicLink {
     } else {
         cmd /c "mklink `"$Link`" `"$Target`"" | Out-Null
     }
+
+    if ($LASTEXITCODE -ne 0) {
+        # Windows requires admin privileges to create symbolic links
+        # unless Developer Mode has been enabled.
+        throw "Failed to create symbolic link at $Link that points to $Target"
+    }
 }
 
 # Stage all artifacts

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -47,6 +47,9 @@ jobs:
         EnableCompliance: ${{ parameters.EnableCompliance }}
         EnableAPIScan: ${{ parameters.EnableAPIScan }}
 
+  - script: dotnet format --verify-no-changes --no-restore
+    displayName: 💅 Verify formatted code
+
   - template: publish-symbols.yml
   - ${{ if parameters.RunTests }}:
     - template: publish-codecoverage.yml

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -8,6 +8,7 @@ steps:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  retryCountOnTaskFailure: 3 # fails when the cloud service is overloaded
 
 - task: MicroBuildSigningPlugin@4
   inputs:

--- a/azure-pipelines/variables/TeamName.ps1
+++ b/azure-pipelines/variables/TeamName.ps1
@@ -1,2 +1,2 @@
-# This value is used to craft a \\cpvsbuild\drops path for symbol archival.
+# This value is used as an input to the MicroBuild Insert VS task.
 'VS IDE'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/settings.VisualStudio.json
+++ b/settings.VisualStudio.json
@@ -1,0 +1,3 @@
+{
+  "textEditor.codeCleanup.profile": "profile1"
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>
     <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockTaskSchedulerService.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Mocks/MockTaskSchedulerService.cs
@@ -58,7 +58,7 @@ internal sealed class MockTaskSchedulerService : IVsTaskSchedulerService, IVsTas
     public object GetAsyncTaskContext() => this.joinableTaskContext;
 
     /// <inheritdoc />
-    public object GetTaskScheduler([ComAliasName("VsShell.VSTASKRUNCONTEXT")]uint context)
+    public object GetTaskScheduler([ComAliasName("VsShell.VSTASKRUNCONTEXT")] uint context)
     {
         var runContext = (VsTaskRunContext)context;
         if (runContext == VsTaskRunContext.CurrentContext)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>


### PR DESCRIPTION
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microbuild version to 2.0.137
- Tolerate NOTICE file task network failures
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Fix typo in comment
- Bump MicroBuildVersion to 2.0.146
- Bump dotnet-coverage to 17.8.6
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
- Bump dotnet-coverage to 17.8.7
- Revert "Bump dotnet-coverage to 17.8.7"
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Bump powershell from 7.3.8 to 7.3.9 (#227)
- Bump xunit from 2.5.3 to 2.6.1 (#228)
- Ignore `dotnet-format` v9 versions
- Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#229)
- Apply Directory.Packages.props in Apply-Template.ps1
- Bump to the .NET 8.0.100 SDK
- Bump xunit from 2.6.1 to 2.6.2 (#234)
- Bump Microsoft.SourceLink.GitHub from 1.1.1 to 8.0.0 (#232)
- Bump powershell from 7.3.9 to 7.4.0 (#231)
- Bump xunit.runner.visualstudio from 2.5.3 to 2.5.4 (#233)
- Validate formatted code in builds
- Enable auto-format on save in VS and VS Code
- Remove `dotnet-format` as a tool
- Make symbolic link failures more detectable
- Update TeamName comment
- Add xml header to msbuild files
- Update Microsoft.SourceLink.AzureRepos.Git to 8.0.0
- Stop VS Code from wrapping xml files
- Add dotnet_separate_import_directive_groups to .editorconfig
- Bump xunit from 2.6.2 to 2.6.3 (#239)
- Bump dotnet-coverage from 17.9.3 to 17.9.5 (#238)
- Bump xunit.runner.visualstudio from 2.5.4 to 2.5.5 (#237)
- Include SBOM in nuget packages
- Fix `Install-NuGetPackage` exit code check
