### PR TITLE
Add support for unit-testing client callbacks on brokered services

### DIFF
--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -6,7 +6,6 @@ using System.IO.Pipelines;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
-using Xunit;
 
 namespace Microsoft.VisualStudio.Sdk.TestFramework;
 
@@ -161,8 +160,7 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
-        this.ConfigureServiceProxy(clientConnection, serverConnection);
-        this.ConfigureClientCallbackProxy(clientConnection, serverConnection);
+        this.ConfigureRpcConnections(clientConnection, serverConnection);
     }
 
     /// <inheritdoc/>
@@ -278,26 +276,16 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     }
 
     /// <summary>
-    /// Configures a proxy for the mocked brokered service.
+    /// Configures the targets and proxies for the RPC connections.
     /// </summary>
     /// <param name="clientConnection">RPC connection to the test class (client).</param>
     /// <param name="serverConnection">RPC connection to the mocked service (server).</param>
-    protected virtual void ConfigureServiceProxy(ServiceRpcDescriptor.RpcConnection clientConnection, ServiceRpcDescriptor.RpcConnection serverConnection)
+    protected virtual void ConfigureRpcConnections([ValidatedNotNull] ServiceRpcDescriptor.RpcConnection clientConnection, [ValidatedNotNull] ServiceRpcDescriptor.RpcConnection serverConnection)
     {
         Requires.NotNull(serverConnection, nameof(serverConnection));
         Requires.NotNull(clientConnection, nameof(clientConnection));
 
         this.ClientProxy = clientConnection.ConstructRpcClient<TInterface>();
         serverConnection.AddLocalRpcTarget(this.Service);
-    }
-
-    /// <summary>
-    /// Configures a proxy for the mocked client callback.
-    /// </summary>
-    /// <param name="clientConnection">RPC connection to the test class (client).</param>
-    /// <param name="serverConnection">RPC connection to the mocked service (server).</param>
-    protected virtual void ConfigureClientCallbackProxy(ServiceRpcDescriptor.RpcConnection clientConnection, ServiceRpcDescriptor.RpcConnection serverConnection)
-    {
-        return;
     }
 }

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -80,9 +80,9 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     protected SourceLevels DescriptorLoggingVerbosity { get; set; } = SourceLevels.Verbose;
 
     /// <summary>
-    /// Gets the testCounter 
+    /// Gets the test count.
     /// </summary>
-    protected int TestCounter { get { return testCounter; } }
+    protected int TestCounter => testCounter;
 
     /// <inheritdoc/>
     public virtual async Task InitializeAsync()

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -78,11 +78,6 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// </summary>
     protected SourceLevels DescriptorLoggingVerbosity { get; set; } = SourceLevels.Verbose;
 
-    /// <summary>
-    /// Gets the test count.
-    /// </summary>
-    protected int TestCounter => testCounter;
-
     /// <inheritdoc/>
     public virtual async Task InitializeAsync()
     {

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -26,7 +26,7 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// Test logs can get misattributed to the wrong test, and prefixing each logged message with a number makes this detectable.
     /// See <see href="https://github.com/microsoft/vstest/issues/3047">this bug</see>.
     /// </remarks>
-    private static int testCounter;
+    protected static int testCounter;
 
     private MultiplexingStream clientMxStream;
     private MultiplexingStream serviceMxStream;
@@ -79,16 +79,11 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// </summary>
     protected SourceLevels DescriptorLoggingVerbosity { get; set; } = SourceLevels.Verbose;
 
-    /// <summary>
-    /// Gets or sets the factory function for creating a trace source.
-    /// </summary>
-    protected Func<string, SourceLevels, TraceSource> TraceSourceFactory { get; set; }
-
     /// <inheritdoc/>
-    public async Task InitializeAsync()
+    public virtual async Task InitializeAsync()
     {
         int testId = Interlocked.Increment(ref testCounter);
-        this.TraceSourceFactory = (name, verbosity) =>
+        Func<string, SourceLevels, TraceSource> traceSourceFactory = (name, verbosity) =>
             new TraceSource(name)
             {
                 Switch = { Level = verbosity },
@@ -98,16 +93,6 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
                 },
             };
 
-        await ConfigureClientProxyAndServiceAsync();
-        await ConfigureClientInterfaceAsync();
-    }
-
-    /// <summary>
-    /// Configures a proxy for the mocked brokered service.
-    /// </summary>
-    /// <returns>A Task object.</returns>
-    protected virtual async Task ConfigureClientProxyAndServiceAsync()
-    {
         if (this.Descriptor is ServiceJsonRpcDescriptor { MultiplexingStreamOptions: object } descriptor)
         {
             // This is a V3 descriptor, which sets up its own MultiplexingStream.
@@ -115,18 +100,18 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
             this.ClientProxy = descriptor
                 .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
                 {
-                    TraceSource = this.TraceSourceFactory?.Invoke("Client mxstream", this.MultiplexingLoggingVerbosity),
-                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    TraceSource = traceSourceFactory("Client mxstream", this.MultiplexingLoggingVerbosity),
+                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
                 })
-                .WithTraceSource(this.TraceSourceFactory?.Invoke("Client RPC", this.DescriptorLoggingVerbosity))
+                .WithTraceSource(traceSourceFactory("Client RPC", this.DescriptorLoggingVerbosity))
                 .ConstructRpc<TInterface>(underlyingPipes.Item1);
             descriptor
                 .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
                 {
-                    TraceSource = this.TraceSourceFactory?.Invoke("Server mxstream", this.MultiplexingLoggingVerbosity),
-                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    TraceSource = traceSourceFactory("Server mxstream", this.MultiplexingLoggingVerbosity),
+                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
                 })
-                .WithTraceSource(this.TraceSourceFactory?.Invoke("Server RPC", this.DescriptorLoggingVerbosity))
+                .WithTraceSource(traceSourceFactory("Server RPC", this.DescriptorLoggingVerbosity))
                 .ConstructRpc(this.Service, underlyingPipes.Item2);
         }
         else
@@ -137,16 +122,16 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
                 underlyingStreams.Item1,
                 new MultiplexingStream.Options
                 {
-                    TraceSource = this.TraceSourceFactory?.Invoke("Client mxstream", this.MultiplexingLoggingVerbosity),
-                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    TraceSource = traceSourceFactory("Client mxstream", this.MultiplexingLoggingVerbosity),
+                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
                 },
                 this.TimeoutToken);
             Task<MultiplexingStream> mxStreamTask2 = MultiplexingStream.CreateAsync(
                 underlyingStreams.Item2,
                 new MultiplexingStream.Options
                 {
-                    TraceSource = this.TraceSourceFactory?.Invoke("Server mxstream", this.MultiplexingLoggingVerbosity),
-                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    TraceSource = traceSourceFactory("Server mxstream", this.MultiplexingLoggingVerbosity),
+                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
                 },
                 this.TimeoutToken);
             MultiplexingStream[] mxStreams = await Task.WhenAll(mxStreamTask1, mxStreamTask2);
@@ -159,24 +144,15 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
 
 #pragma warning disable CS0618 // Type or member is obsolete
             this.ClientProxy = this.Descriptor
-                .WithTraceSource(this.TraceSourceFactory?.Invoke("Client RPC", this.DescriptorLoggingVerbosity))
+                .WithTraceSource(traceSourceFactory("Client RPC", this.DescriptorLoggingVerbosity))
                 .WithMultiplexingStream(mxStreams[0])
                 .ConstructRpc<TInterface>(channels[0]);
             this.Descriptor
-                .WithTraceSource(this.TraceSourceFactory?.Invoke("Server RPC", this.DescriptorLoggingVerbosity))
+                .WithTraceSource(traceSourceFactory("Server RPC", this.DescriptorLoggingVerbosity))
                 .WithMultiplexingStream(mxStreams[1])
                 .ConstructRpc(this.Service, channels[1]);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
-    }
-
-    /// <summary>
-    /// Configures a proxy for the mocked client callback that is given to the mocked brokered service.
-    /// </summary>
-    /// <returns>A Task object.</returns>
-    protected virtual async Task ConfigureClientInterfaceAsync()
-    {
-        await Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -26,7 +26,7 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// Test logs can get misattributed to the wrong test, and prefixing each logged message with a number makes this detectable.
     /// See <see href="https://github.com/microsoft/vstest/issues/3047">this bug</see>.
     /// </remarks>
-    protected static int testCounter;
+    private static int testCounter;
 
     private MultiplexingStream clientMxStream;
     private MultiplexingStream serviceMxStream;
@@ -78,6 +78,11 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// Gets or sets the verbosity level to use for logging messages related to the RPC calls between client and service.
     /// </summary>
     protected SourceLevels DescriptorLoggingVerbosity { get; set; } = SourceLevels.Verbose;
+
+    /// <summary>
+    /// Gets the testCounter 
+    /// </summary>
+    protected int TestCounter { get { return testCounter; } }
 
     /// <inheritdoc/>
     public virtual async Task InitializeAsync()

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -280,8 +280,8 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// <summary>
     /// Configures a proxy for the mocked brokered service.
     /// </summary>
-    /// <param name="clientConnection">RPC connection to the proxy.</param>
-    /// <param name="serverConnection">RPC connection to the mocked instance.</param>
+    /// <param name="clientConnection">RPC connection to the test class (client).</param>
+    /// <param name="serverConnection">RPC connection to the mocked service (server).</param>
     protected virtual void ConfigureServiceProxy(ServiceRpcDescriptor.RpcConnection clientConnection, ServiceRpcDescriptor.RpcConnection serverConnection)
     {
         Requires.NotNull(serverConnection, nameof(serverConnection));
@@ -294,8 +294,8 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
     /// <summary>
     /// Configures a proxy for the mocked client callback.
     /// </summary>
-    /// <param name="clientConnection">RPC connection to the proxy.</param>
-    /// <param name="serverConnection">RPC connection to the mocked instance.</param>
+    /// <param name="clientConnection">RPC connection to the test class (client).</param>
+    /// <param name="serverConnection">RPC connection to the mocked service (server).</param>
     protected virtual void ConfigureClientCallbackProxy(ServiceRpcDescriptor.RpcConnection clientConnection, ServiceRpcDescriptor.RpcConnection serverConnection)
     {
         return;

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`2.cs
@@ -161,6 +161,9 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock> 
         }
 
         this.ConfigureRpcConnections(clientConnection, serverConnection);
+
+        clientConnection.StartListening();
+        serverConnection.StartListening();
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
@@ -8,140 +8,47 @@ using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
 using Xunit;
 
-namespace Microsoft.VisualStudio.Sdk.TestFramework
+namespace Microsoft.VisualStudio.Sdk.TestFramework;
+
+/// <summary>
+/// A base class for testing Visual Studio brokered service contracts with client callbacks.
+/// </summary>
+/// <typeparam name="TInterface">The service interface.</typeparam>
+/// <typeparam name="TServiceMock">The class that mocks the service.</typeparam>
+/// <typeparam name="TClientInterfaceMock">The class that mockes the service's client callback.</typeparam>
+public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterfaceMock> : BrokeredServiceContractTestBase<TInterface, TServiceMock>
+    where TInterface : class
+    where TServiceMock : TInterface, IMockServiceWithClientCallback, new()
+    where TClientInterfaceMock : class, new()
 {
     /// <summary>
-    /// A base class for testing Visual Studio brokered service contracts with client callbacks.
+    /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterfaceMock}"/> class.
     /// </summary>
-    /// <typeparam name="TInterface">The service interface.</typeparam>
-    /// <typeparam name="TServiceMock">The class that mocks the service.</typeparam>
-    /// <typeparam name="TClientInterfaceMock">The class that mockes the service's client callback.</typeparam>
-    public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterfaceMock> : BrokeredServiceContractTestBase<TInterface, TServiceMock>
-        where TInterface : class
-        where TServiceMock : TInterface, IMockServiceWithClientCallback, new()
-        where TClientInterfaceMock : class, new()
+    /// <param name="logger"><inheritdoc cref="LoggingTestBase(ITestOutputHelper)" path="/param[@name='logger']"/></param>
+    /// <param name="serviceRpcDescriptor">The descriptor that the product will use to request or proffer the brokered service.</param>
+    public BrokeredServiceContractTestBase(ITestOutputHelper logger, ServiceRpcDescriptor serviceRpcDescriptor)
+        : base(logger, serviceRpcDescriptor)
     {
-        private MultiplexingStream? clientCallbackClientMxStream;
-        private MultiplexingStream? clientCallbackServiceMxStream;
+        Assert.NotNull(serviceRpcDescriptor.ClientInterface);
+        Assert.Equal(typeof(TClientInterfaceMock), serviceRpcDescriptor.ClientInterface.GetType());
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterfaceMock}"/> class.
-        /// </summary>
-        /// <param name="logger"><inheritdoc cref="LoggingTestBase(ITestOutputHelper)" path="/param[@name='logger']"/></param>
-        /// <param name="serviceRpcDescriptor">The descriptor that the product will use to request or proffer the brokered service.</param>
-        public BrokeredServiceContractTestBase(ITestOutputHelper logger, ServiceRpcDescriptor serviceRpcDescriptor)
-            : base(logger, serviceRpcDescriptor)
-        {
-            Assert.NotNull(serviceRpcDescriptor.ClientInterface);
-            Assert.Equal(typeof(TClientInterfaceMock), serviceRpcDescriptor.ClientInterface.GetType());
+        this.ClientInterface = new TClientInterfaceMock();
+    }
 
-            this.ClientInterface = new TClientInterfaceMock();
-        }
+    /// <summary>
+    /// Gets or sets the mock client callback instance.
+    /// </summary>
+    public TClientInterfaceMock ClientInterface { get; protected set; }
 
-        /// <summary>
-        /// Gets or sets the mock client callback instance.
-        /// </summary>
-        public TClientInterfaceMock ClientInterface { get; protected set; }
+    /// <inheritdoc/>
+    protected override void ConfigureClientCallbackProxy(ServiceRpcDescriptor.RpcConnection clientConnection, ServiceRpcDescriptor.RpcConnection serverConnection)
+    {
+        Requires.NotNull(serverConnection, nameof(serverConnection));
+        Requires.NotNull(clientConnection, nameof(clientConnection));
 
-        /// <inheritdoc/>
-        public override async Task InitializeAsync()
-        {
-            await base.InitializeAsync();
+        base.ConfigureClientCallbackProxy(clientConnection, serverConnection);
 
-            int testId = this.TestCounter;
-            Func<string, SourceLevels, TraceSource> traceSourceFactory = (name, verbosity) =>
-                new TraceSource(name)
-                {
-                    Switch = { Level = verbosity },
-                    Listeners =
-                    {
-                    new XunitTraceListener(this.Logger, testId, this.TestStopwatch),
-                    },
-                };
-
-            if (this.Descriptor is ServiceJsonRpcDescriptor { MultiplexingStreamOptions: object } descriptor)
-            {
-                // This is a V3 descriptor, which sets up its own MultiplexingStream.
-                (IDuplexPipe, IDuplexPipe) underlyingPipes = FullDuplexStream.CreatePipePair();
-                (this.Service as IMockServiceWithClientCallback).ClientCallback = descriptor
-                    .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
-                    {
-                        TraceSource = traceSourceFactory("Client mxstream", this.MultiplexingLoggingVerbosity),
-                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
-                    })
-                    .WithTraceSource(traceSourceFactory("Client RPC", this.DescriptorLoggingVerbosity))
-                    .ConstructRpc<TClientInterfaceMock>(underlyingPipes.Item1);
-                descriptor
-                    .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
-                    {
-                        TraceSource = traceSourceFactory("Server mxstream", this.MultiplexingLoggingVerbosity),
-                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
-                    })
-                    .WithTraceSource(traceSourceFactory("Server RPC", this.DescriptorLoggingVerbosity))
-                    .ConstructRpc(this.ClientInterface, underlyingPipes.Item2);
-            }
-            else
-            {
-                // This is an older descriptor that we have to set up the multiplexing stream ourselves for.
-                (Stream, Stream) underlyingStreams = FullDuplexStream.CreatePair();
-                Task<MultiplexingStream> mxStreamTask1 = MultiplexingStream.CreateAsync(
-                    underlyingStreams.Item1,
-                    new MultiplexingStream.Options
-                    {
-                        TraceSource = traceSourceFactory("Client mxstream", this.MultiplexingLoggingVerbosity),
-                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
-                    },
-                    this.TimeoutToken);
-                Task<MultiplexingStream> mxStreamTask2 = MultiplexingStream.CreateAsync(
-                    underlyingStreams.Item2,
-                    new MultiplexingStream.Options
-                    {
-                        TraceSource = traceSourceFactory("Server mxstream", this.MultiplexingLoggingVerbosity),
-                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => traceSourceFactory($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
-                    },
-                    this.TimeoutToken);
-                MultiplexingStream[] mxStreams = await Task.WhenAll(mxStreamTask1, mxStreamTask2);
-                this.clientCallbackClientMxStream = mxStreams[0];
-                this.clientCallbackServiceMxStream = mxStreams[1];
-
-                Task<MultiplexingStream.Channel> offerTask = mxStreams[0].OfferChannelAsync(string.Empty, this.TimeoutToken);
-                Task<MultiplexingStream.Channel> acceptTask = mxStreams[1].AcceptChannelAsync(string.Empty, this.TimeoutToken);
-                MultiplexingStream.Channel[] channels = await Task.WhenAll(offerTask, acceptTask);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-                (this.Service as IMockServiceWithClientCallback).ClientCallback = this.Descriptor
-                    .WithTraceSource(traceSourceFactory("Client RPC", this.DescriptorLoggingVerbosity))
-                    .WithMultiplexingStream(mxStreams[0])
-                    .ConstructRpc<TClientInterfaceMock>(channels[0]);
-                this.Descriptor
-                    .WithTraceSource(traceSourceFactory("Server RPC", this.DescriptorLoggingVerbosity))
-                    .WithMultiplexingStream(mxStreams[1])
-                    .ConstructRpc(this.ClientInterface, channels[1]);
-#pragma warning restore CS0618 // Type or member is obsolete
-            }
-        }
-
-        /// <inheritdoc/>
-        public override async Task DisposeAsync()
-        {
-            await base.DisposeAsync();
-
-            (this.ClientInterface as IDisposable)?.Dispose();
-
-            List<Task> tasks = new();
-            if (this.clientCallbackClientMxStream is not null)
-            {
-                tasks.Add(this.clientCallbackClientMxStream.DisposeAsync().AsTask());
-                tasks.Add(this.clientCallbackClientMxStream.Completion);
-            }
-
-            if (this.clientCallbackServiceMxStream is not null)
-            {
-                tasks.Add(this.clientCallbackServiceMxStream.DisposeAsync().AsTask());
-                tasks.Add(this.clientCallbackServiceMxStream.Completion);
-            }
-
-            await Task.WhenAll(tasks);
-        }
+        (this.Service as IMockServiceWithClientCallback).ClientCallback = serverConnection.ConstructRpcClient<TClientInterfaceMock>();
+        clientConnection.AddLocalRpcTarget(this.ClientInterface);
     }
 }

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Sdk.TestFramework
         {
             await base.InitializeAsync();
 
-            int testId = TestCounter;
+            int testId = this.TestCounter;
             Func<string, SourceLevels, TraceSource> traceSourceFactory = (name, verbosity) =>
                 new TraceSource(name)
                 {

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
@@ -41,14 +41,14 @@ namespace Microsoft.VisualStudio.Sdk.TestFramework
         /// <summary>
         /// Gets or sets the mock client callback instance.
         /// </summary>
-        public TClientInterfaceMock? ClientInterface { get; protected set; }
+        public TClientInterfaceMock ClientInterface { get; protected set; }
 
         /// <inheritdoc/>
         public override async Task InitializeAsync()
         {
-            base.InitializeAsync();
+            await base.InitializeAsync();
 
-            int testId = testCounter;
+            int testId = TestCounter;
             Func<string, SourceLevels, TraceSource> traceSourceFactory = (name, verbosity) =>
                 new TraceSource(name)
                 {

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`3.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Sdk.TestFramework
+{
+    /// <summary>
+    /// A base class for testing Visual Studio brokered service contracts with client callbacks.
+    /// </summary>
+    /// <typeparam name="TInterface">The service interface.</typeparam>
+    /// <typeparam name="TServiceMock">The class that mocks the service.</typeparam>
+    /// <typeparam name="TClientInterfaceMock">The class that mockes the service's client callback.</typeparam>
+    public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterfaceMock> : BrokeredServiceContractTestBase<TInterface, TServiceMock>
+        where TInterface : class
+        where TServiceMock : TInterface, IMockServiceWithClientCallback, new()
+        where TClientInterfaceMock : class, new()
+    {
+        private MultiplexingStream? clientCallbackClientMxStream;
+        private MultiplexingStream? clientCallbackServiceMxStream;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterfaceMock}"/> class.
+        /// </summary>
+        /// <param name="logger"><inheritdoc cref="LoggingTestBase(ITestOutputHelper)" path="/param[@name='logger']"/></param>
+        /// <param name="serviceRpcDescriptor">The descriptor that the product will use to request or proffer the brokered service.</param>
+        public BrokeredServiceContractTestBase(ITestOutputHelper logger, ServiceRpcDescriptor serviceRpcDescriptor)
+            : base(logger, serviceRpcDescriptor)
+        {
+            Assert.NotNull(serviceRpcDescriptor.ClientInterface);
+            Assert.Equal(typeof(TClientInterfaceMock), serviceRpcDescriptor.ClientInterface.GetType());
+
+            this.ClientInterface = new TClientInterfaceMock();
+        }
+
+        /// <summary>
+        /// Gets or sets the mock client callback instance.
+        /// </summary>
+        public TClientInterfaceMock? ClientInterface { get; protected set; }
+
+        /// <inheritdoc/>
+        public override async Task DisposeAsync()
+        {
+            await base.DisposeAsync();
+
+            (this.ClientInterface as IDisposable)?.Dispose();
+
+            List<Task> tasks = new();
+            if (this.clientCallbackClientMxStream is not null)
+            {
+                tasks.Add(this.clientCallbackClientMxStream.DisposeAsync().AsTask());
+                tasks.Add(this.clientCallbackClientMxStream.Completion);
+            }
+
+            if (this.clientCallbackServiceMxStream is not null)
+            {
+                tasks.Add(this.clientCallbackServiceMxStream.DisposeAsync().AsTask());
+                tasks.Add(this.clientCallbackServiceMxStream.Completion);
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        /// <inheritdoc/>
+        protected override async Task ConfigureClientInterfaceAsync()
+        {
+            if (this.Descriptor is ServiceJsonRpcDescriptor { MultiplexingStreamOptions: object } descriptor)
+            {
+                // This is a V3 descriptor, which sets up its own MultiplexingStream.
+                (IDuplexPipe, IDuplexPipe) underlyingPipes = FullDuplexStream.CreatePipePair();
+                (this.Service as IMockServiceWithClientCallback).ClientCallback = descriptor
+                    .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
+                    {
+                        TraceSource = this.TraceSourceFactory?.Invoke("Client mxstream", this.MultiplexingLoggingVerbosity),
+                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    })
+                    .WithTraceSource(this.TraceSourceFactory?.Invoke("Client RPC", this.DescriptorLoggingVerbosity))
+                    .ConstructRpc<TClientInterfaceMock>(underlyingPipes.Item1);
+                descriptor
+                    .WithMultiplexingStream(new MultiplexingStream.Options(descriptor.MultiplexingStreamOptions)
+                    {
+                        TraceSource = this.TraceSourceFactory?.Invoke("Server mxstream", this.MultiplexingLoggingVerbosity),
+                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    })
+                    .WithTraceSource(this.TraceSourceFactory?.Invoke("Server RPC", this.DescriptorLoggingVerbosity))
+                    .ConstructRpc(this.ClientInterface, underlyingPipes.Item2);
+            }
+            else
+            {
+                // This is an older descriptor that we have to set up the multiplexing stream ourselves for.
+                (Stream, Stream) underlyingStreams = FullDuplexStream.CreatePair();
+                Task<MultiplexingStream> mxStreamTask1 = MultiplexingStream.CreateAsync(
+                    underlyingStreams.Item1,
+                    new MultiplexingStream.Options
+                    {
+                        TraceSource = this.TraceSourceFactory?.Invoke("Client mxstream", this.MultiplexingLoggingVerbosity),
+                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Client mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    },
+                    this.TimeoutToken);
+                Task<MultiplexingStream> mxStreamTask2 = MultiplexingStream.CreateAsync(
+                    underlyingStreams.Item2,
+                    new MultiplexingStream.Options
+                    {
+                        TraceSource = this.TraceSourceFactory?.Invoke("Server mxstream", this.MultiplexingLoggingVerbosity),
+                        DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => this.TraceSourceFactory?.Invoke($"Server mxstream {id} (\"{name}\")", this.MultiplexingLoggingVerbosity),
+                    },
+                    this.TimeoutToken);
+                MultiplexingStream[] mxStreams = await Task.WhenAll(mxStreamTask1, mxStreamTask2);
+                this.clientCallbackClientMxStream = mxStreams[0];
+                this.clientCallbackServiceMxStream = mxStreams[1];
+
+                Task<MultiplexingStream.Channel> offerTask = mxStreams[0].OfferChannelAsync(string.Empty, this.TimeoutToken);
+                Task<MultiplexingStream.Channel> acceptTask = mxStreams[1].AcceptChannelAsync(string.Empty, this.TimeoutToken);
+                MultiplexingStream.Channel[] channels = await Task.WhenAll(offerTask, acceptTask);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                (this.Service as IMockServiceWithClientCallback).ClientCallback = this.Descriptor
+                    .WithTraceSource(this.TraceSourceFactory?.Invoke("Client RPC", this.DescriptorLoggingVerbosity))
+                    .WithMultiplexingStream(mxStreams[0])
+                    .ConstructRpc<TClientInterfaceMock>(channels[0]);
+                this.Descriptor
+                    .WithTraceSource(this.TraceSourceFactory?.Invoke("Server RPC", this.DescriptorLoggingVerbosity))
+                    .WithMultiplexingStream(mxStreams[1])
+                    .ConstructRpc(this.ClientInterface, channels[1]);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`4.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`4.cs
@@ -10,11 +10,13 @@ namespace Microsoft.VisualStudio.Sdk.TestFramework;
 /// </summary>
 /// <typeparam name="TInterface">The service interface.</typeparam>
 /// <typeparam name="TServiceMock">The class that mocks the service.</typeparam>
+/// <typeparam name="TClientInterface">The interface of the client callback.</typeparam>
 /// <typeparam name="TClientMock">The class that mocks the service's client callback.</typeparam>
-public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientMock> : BrokeredServiceContractTestBase<TInterface, TServiceMock>
+public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterface, TClientMock> : BrokeredServiceContractTestBase<TInterface, TServiceMock>
     where TInterface : class
     where TServiceMock : TInterface, IMockServiceWithClientCallback, new()
-    where TClientMock : class, new()
+    where TClientInterface : class
+    where TClientMock : TClientInterface, new()
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterfaceMock}"/> class.
@@ -39,7 +41,7 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, 
     {
         base.ConfigureRpcConnections(clientConnection, serverConnection);
 
-        this.Service.ClientCallback = serverConnection.ConstructRpcClient<TClientMock>();
+        this.Service.ClientCallback = serverConnection.ConstructRpcClient<TClientInterface>();
         clientConnection.AddLocalRpcTarget(this.ClientCallback);
     }
 }

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`4.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/BrokeredServiceContractTestBase`4.cs
@@ -19,7 +19,7 @@ public abstract class BrokeredServiceContractTestBase<TInterface, TServiceMock, 
     where TClientMock : TClientInterface, new()
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterfaceMock}"/> class.
+    /// Initializes a new instance of the <see cref="BrokeredServiceContractTestBase{TInterface, TServiceMock, TClientInterface, TClientMock}"/> class.
     /// </summary>
     /// <param name="logger"><inheritdoc cref="LoggingTestBase(ITestOutputHelper)" path="/param[@name='logger']"/></param>
     /// <param name="serviceRpcDescriptor">The descriptor that the product will use to request or proffer the brokered service.</param>

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Sdk.TestFramework
+{
+    public interface IMockServiceWithClientCallback
+    {
+        public object ClientCallback { get; set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
@@ -7,16 +7,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.VisualStudio.Sdk.TestFramework
+namespace Microsoft.VisualStudio.Sdk.TestFramework;
+
+/// <summary>
+/// Interface for service mocks that need to interact with a client callback proxy.
+/// </summary>
+public interface IMockServiceWithClientCallback
 {
     /// <summary>
-    /// Interface for service mocks that need to interact with a client callback proxy.
+    /// Gets or sets the proxy to a client callback object.
     /// </summary>
-    public interface IMockServiceWithClientCallback
-    {
-        /// <summary>
-        /// Gets or sets the proxy to a client callback object.
-        /// </summary>
-        public object ClientCallback { get; set; }
-    }
+    public object ClientCallback { get; set; }
 }

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/IMockServiceWithClientCallback.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,8 +9,14 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Sdk.TestFramework
 {
+    /// <summary>
+    /// Interface for service mocks that need to interact with a client callback proxy.
+    /// </summary>
     public interface IMockServiceWithClientCallback
     {
+        /// <summary>
+        /// Gets or sets the proxy to a client callback object.
+        /// </summary>
         public object ClientCallback { get; set; }
     }
 }

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/Descriptors.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/Descriptors.cs
@@ -12,4 +12,12 @@ internal static class Descriptors
         ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
         new Nerdbank.Streams.MultiplexingStream.Options { ProtocolMajorVersion = 3 })
         .WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.ISerializable);
+
+    internal static readonly ServiceRpcDescriptor Greet = new ServiceJsonRpcDescriptor(
+        new ServiceMoniker("Greet", new Version(1, 0)),
+        clientInterface: typeof(ISayName),
+        ServiceJsonRpcDescriptor.Formatters.MessagePack,
+        ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+        new Nerdbank.Streams.MultiplexingStream.Options { ProtocolMajorVersion = 3 })
+        .WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.ISerializable);
 }

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/IGreet.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/IGreet.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public interface IGreet
+{
+    event EventHandler<string> GreetingSent;
+
+    event EventHandler OperationComplete;
+
+    ValueTask<string> MakeGreeting(CancellationToken cancellationToken);
+}

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/ISayName.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceContracts/ISayName.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public interface ISayName
+{
+    public ValueTask<string> SayName();
+}

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceTests2.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceTests2.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-public class BrokeredServiceTests : BrokeredServiceContractTestBase<ICalculator, CalculatorMock>
+public class BrokeredServiceTests2 : BrokeredServiceContractTestBase<ICalculator, CalculatorMock>
 {
-    public BrokeredServiceTests(ITestOutputHelper logger)
+    public BrokeredServiceTests2(ITestOutputHelper logger)
         : base(logger, Descriptors.Calculator)
     {
     }

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceTests4.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/BrokeredServiceTests4.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class BrokeredServiceTests4 : BrokeredServiceContractTestBase<IGreet, GreetMock, ISayName, SayNameMock>
+{
+    public BrokeredServiceTests4(ITestOutputHelper logger)
+        : base(logger, Descriptors.Greet)
+    {
+    }
+
+    [Fact]
+    public async Task MakeGreeting()
+    {
+        Assert.Equal("Nice to meet you, Daffy Duck.", await this.ClientProxy.MakeGreeting(this.TimeoutToken));
+    }
+
+    [Fact]
+    public async Task GreetingMade()
+    {
+        var name = await this.ClientCallback.SayName();
+        await this.AssertEventRaisedAsync<string>(
+            (p, h) => p.GreetingSent += h,
+            (p, h) => p.GreetingSent -= h,
+            s => s.SendGreeting($"Nice to meet you, {name}."),
+            a => Assert.Equal("Nice to meet you, Daffy Duck.", a));
+    }
+
+    [Fact]
+    public async Task OperationComplete()
+    {
+        await this.AssertEventRaisedAsync(
+            (p, h) => p.OperationComplete += h,
+            (p, h) => p.OperationComplete -= h,
+            s => s.RaiseOperationComplete());
+    }
+}

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/GreetMock.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/GreetMock.cs
@@ -9,13 +9,11 @@ public class GreetMock : IGreet, IMockServiceWithClientCallback
 
     public event EventHandler? OperationComplete;
 
-    public object ClientCallback { get; set; } = new object();
+    public object ClientCallback { get; set; } = null!;
 
     public async ValueTask<string> MakeGreeting(CancellationToken cancellationToken)
     {
-#pragma warning disable CS8605
-        var name = await (ValueTask<string>)typeof(ISayName).GetMethod("SayName")?.Invoke(this.ClientCallback, null);
-#pragma warning restore CS8605
+        string name = await ((ISayName)this.ClientCallback).SayName();
         return $"Nice to meet you, {name}.";
     }
 

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/GreetMock.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/GreetMock.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using static System.Reflection.BindingFlags;
+
+public class GreetMock : IGreet, IMockServiceWithClientCallback
+{
+    public event EventHandler<string>? GreetingSent;
+
+    public event EventHandler? OperationComplete;
+
+    public object ClientCallback { get; set; } = new object();
+
+    public async ValueTask<string> MakeGreeting(CancellationToken cancellationToken)
+    {
+#pragma warning disable CS8605
+        var name = await (ValueTask<string>)typeof(ISayName).GetMethod("SayName")?.Invoke(this.ClientCallback, null);
+#pragma warning restore CS8605
+        return $"Nice to meet you, {name}.";
+    }
+
+    internal void SendGreeting(string greeting) => this.GreetingSent?.Invoke(this, greeting);
+
+    internal void RaiseOperationComplete() => this.OperationComplete?.Invoke(this, EventArgs.Empty);
+}

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/SayNameMock.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Tests/Mocks/SayNameMock.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class SayNameMock : ISayName
+{
+    public ValueTask<string> SayName() => new("Daffy Duck");
+}


### PR DESCRIPTION
In the current `BrokeredServiceContractTestBase<TInterface, TServiceMock>` class, it's not possible to configure client callbacks on the `TServiceMock` that is provided. In an actual request for a brokered service, we may pass a `Type` to the `ServicerpcDescriptor.ClientInterface` which should provide a callback for the brokered service into the client, but as of today that functionality does not exist to unit test. This PR provides a mechanism to UT such scenarios where a client callback is required.

The main changes in this PR are:
1. Adjust the `InitializeAsync()` method of `BrokeredServiceContractTestBase<TInterface, TServiceMock>` so that it sets up RPC connections for the server and client, and then passes those connections to a `virtual` method which handles configuration of the service and client callback proxies. On the base class, set up the service proxy.
2. Create a new class `BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterface, TClientMock>` that inherits from `BrokeredServiceContractTestBase<TInterface, TServiceMock>` . Override the method for configuring service and client callback proxies so that it will call the base implementation and then set up the client callback proxy.
3. Define a new interface `IMockServiceWithClientCallback` which defines a property `public object ClientInterface` with a get/set method. If a test class derives from `BrokeredServiceContractTestBase<TInterface, TServiceMock, TClientInterface, TClientMock>` then the type passed for `TServiceMock` must implement `IMockServiceWithClientCallback` and the type passed as the `ServiceRpcDescriptor.ClientInterface` must be an instance of `TClientMock`.