### PR TITLE
Consume dependencies with versions available from nuget.org

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,10 +10,10 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.11.13" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.11.39607" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.11.40262" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.11.40262" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.11.39607" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.11.40262" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.4.22" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.11.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.11.13" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.11.39607" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.11.39607" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.11.39607" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.11.40262" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.11.39607" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework.Testing" Version="4.4.22" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />


### PR DESCRIPTION
Fixes compiler warnings:

NU1603: Microsoft.VisualStudio.Sdk.TestFramework 17.11.8 depends on Microsoft.VisualStudio.Composition (>= 17.11.9) but Microsoft.VisualStudio.Composition 17.11.9 was not found. An approximate best match of Microsoft.VisualStudio.Composition 17.11.13 was resolved.

NU1603: Microsoft.VisualStudio.Sdk.TestFramework 17.11.8 depends on Microsoft.VisualStudio.Shell.15.0 (>= 17.11.39607) but Microsoft.VisualStudio.Shell.15.0 17.11.39607 was not found. An approximate best match of Microsoft.VisualStudio.Shell.15.0 17.11.40262 was resolved.