### PR TITLE
Fix docfx build

### DIFF
--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -1,0 +1,22 @@
+name: 📃 Docfx Validate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 📚 docfx
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: ⚙ Install prerequisites
+      run: |
+        ./init.ps1 -UpgradePrerequisites
+        dotnet --info
+      shell: pwsh
+    - name: 📚 Verify docfx build
+      run: dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures
+      if: runner.os == 'Linux'

--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/Microsoft.VisualStudio.Sdk.TestFramework.csproj
@@ -5,6 +5,7 @@
 Xunit test projects should consume via the Microsoft.VisualStudio.Sdk.TestFramework.Xunit package.</Description>
     <Product>Microsoft VisualStudio SDK Test Framework</Product>
     <UseWPF Condition="'$(TargetFramework)'!='net8.0'">true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
[These new builds](https://github.com/microsoft/vssdktestfx/actions/workflows/docs.yml) are failing to build the docs page due to .NET SDK refusing the restore packages on linux unless we tell it to support it.