### PR TITLE
Fix WPF teardown failures in mocked VS tests

### DIFF
--- a/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
+++ b/src/Microsoft.VisualStudio.Sdk.TestFramework/GlobalServiceProvider.cs
@@ -248,7 +248,9 @@ public class GlobalServiceProvider : IDisposable
             {
                 this.mainThreadSyncContext = new DispatcherSynchronizationContext();
                 SynchronizationContext.SetSynchronizationContext(this.mainThreadSyncContext);
-                _ = new Application(); // just creating this sets it to Application.Current, as required
+
+                // Closing a test window must not shut down the application shared by the collection.
+                _ = new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
 
 #pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
                 this.joinableTaskContext = new JoinableTaskContext();
@@ -283,6 +285,11 @@ public class GlobalServiceProvider : IDisposable
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 this.mainThreadInitialized.TrySetException(ex);
+            }
+            finally
+            {
+                // Release WPF's apartment-affine resources before the owning STA exits.
+                Dispatcher.CurrentDispatcher.InvokeShutdown();
             }
         }
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,6 +6,8 @@
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseWPF Condition="'$(TargetFramework)'!='net8.0'">true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/GlobalServiceProviderTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/GlobalServiceProviderTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+
+using System.Windows.Threading;
+
+namespace Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared;
+
+/// <summary>
+/// Tests the lifetime of the mocked VS main thread in isolated application domains.
+/// </summary>
+[Collection(MockedVS.Collection)]
+public class GlobalServiceProviderTests
+{
+    /// <summary>
+    /// Verifies that disposing the service provider releases dispatcher-owned resources before its thread exits.
+    /// </summary>
+    /// <param name="disposeFromMainThread">Whether to dispose on the mocked main thread.</param>
+    /// <param name="shutdownFirst">Whether the dispatcher has already been asked to shut down.</param>
+    /// <returns>A task representing the isolated lifetime check.</returns>
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task Dispose_ShutsDownDispatcherOnOwningThread(bool disposeFromMainThread, bool shutdownFirst)
+    {
+        // Dispose an isolated fixture twice on the selected thread and verify that WPF cleanup runs exactly once
+        // on its owning STA, including when dispatcher shutdown was already requested.
+        var setup = new AppDomainSetup
+        {
+            ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
+            ConfigurationFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile,
+        };
+        AppDomain domain = AppDomain.CreateDomain(nameof(this.Dispose_ShutsDownDispatcherOnOwningThread), null, setup);
+        try
+        {
+            var probe = (DispatcherLifetimeProbe)domain.CreateInstanceAndUnwrap(
+                typeof(DispatcherLifetimeProbe).Assembly.FullName,
+                typeof(DispatcherLifetimeProbe).FullName);
+            using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            (bool threadExited, bool shutdownFinished, int startedCount, int finishedCount, int mainThreadId, int startedThreadId, int finishedThreadId) =
+                await Task.Run(() => probe.Shutdown(disposeFromMainThread, shutdownFirst), timeout.Token).WithCancellation(timeout.Token);
+            Assert.True(threadExited, "The mocked main thread did not exit.");
+            Assert.True(shutdownFinished);
+            Assert.Equal(1, startedCount);
+            Assert.Equal(1, finishedCount);
+            Assert.Equal(mainThreadId, startedThreadId);
+            Assert.Equal(mainThreadId, finishedThreadId);
+        }
+        finally
+        {
+            AppDomain.Unload(domain);
+        }
+    }
+
+    /// <summary>
+    /// Exercises a complete fixture lifetime without changing the test runner's global VS services.
+    /// </summary>
+    public class DispatcherLifetimeProbe : MarshalByRefObject
+    {
+        /// <summary>
+        /// Disposes the fixture and records dispatcher shutdown.
+        /// </summary>
+        /// <param name="disposeFromMainThread">Whether to dispose on the mocked main thread.</param>
+        /// <param name="shutdownFirst">Whether to request dispatcher shutdown before disposal.</param>
+        /// <returns>The thread and dispatcher state after disposal.</returns>
+        public (bool ThreadExited, bool ShutdownFinished, int StartedCount, int FinishedCount, int MainThreadId, int StartedThreadId, int FinishedThreadId) Shutdown(bool disposeFromMainThread, bool shutdownFirst)
+        {
+            var provider = new GlobalServiceProvider();
+            Thread mainThread = ThreadHelper.JoinableTaskContext.MainThread;
+            int shutdownStartedCount = 0;
+            int shutdownFinishedCount = 0;
+            int shutdownStartedThreadId = 0;
+            int shutdownFinishedThreadId = 0;
+            Dispatcher dispatcher = ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken.None);
+                Dispatcher current = Dispatcher.CurrentDispatcher;
+                current.ShutdownStarted += (sender, args) =>
+                {
+                    shutdownStartedCount++;
+                    shutdownStartedThreadId = Thread.CurrentThread.ManagedThreadId;
+                };
+                current.ShutdownFinished += (sender, args) =>
+                {
+                    shutdownFinishedCount++;
+                    shutdownFinishedThreadId = Thread.CurrentThread.ManagedThreadId;
+                };
+
+                if (shutdownFirst)
+                {
+                    current.InvokeShutdown();
+                }
+
+                if (disposeFromMainThread)
+                {
+                    provider.Dispose();
+                    provider.Dispose();
+                }
+
+                return current;
+            });
+
+            if (!disposeFromMainThread)
+            {
+                provider.Dispose();
+                provider.Dispose();
+            }
+
+            bool threadExited = mainThread.Join(TimeSpan.FromSeconds(10));
+            return (threadExited, dispatcher.HasShutdownFinished, shutdownStartedCount, shutdownFinishedCount, mainThread.ManagedThreadId, shutdownStartedThreadId, shutdownFinishedThreadId);
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared.projitems
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BrokeredServiceTests2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BrokeredServiceTests4.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ChildServiceProviderTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GlobalServiceProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MefHostingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\CalculatorMock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\GreetMock.cs" />

--- a/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/TestFrameworkTests.cs
+++ b/test/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.Tests.Shared/TestFrameworkTests.cs
@@ -4,6 +4,9 @@
 #if NETFRAMEWORK || WINDOWS
 
 using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
@@ -72,6 +75,43 @@ public class TestFrameworkTests : LoggingTestBase
         ThreadHelper.ThrowIfNotOnUIThread();
 #pragma warning restore VSTHRD109 // Switch instead of assert in async methods
         Assert.Throws<COMException>(() => ThreadHelper.ThrowIfOnUIThread());
+    }
+
+    /// <summary>
+    /// Verifies that test windows do not end the shared application lifetime.
+    /// </summary>
+    [Fact]
+    public async Task ClosingWindowPreservesApplication()
+    {
+        // Show and close successive text-input windows on the shared STA, verifying that one test's
+        // last window cannot shut down the application and dispatcher needed by subsequent tests.
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken);
+        Application application = Application.Current;
+        Assert.Equal(ShutdownMode.OnExplicitShutdown, application.ShutdownMode);
+
+        for (int i = 0; i < 2; i++)
+        {
+            var window = new Window
+            {
+                Content = new TextBox(),
+                Width = 200,
+                Height = 100,
+                ShowActivated = false,
+                ShowInTaskbar = false,
+            };
+            try
+            {
+                window.Show();
+                window.Close();
+                await Dispatcher.Yield(DispatcherPriority.ApplicationIdle);
+                Assert.Same(application, Application.Current);
+                Assert.False(application.Dispatcher.HasShutdownStarted);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
     }
 
     [Fact]

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -112,11 +112,12 @@ if ($isMTP) {
         )
     }
 
+    # Allow instrumented discovery to finish before the first test-start event, as in the MTP path.
     & $dotnet test $RepoRoot `
         --no-build `
         -c $Configuration `
         --filter "TestCategory!=FailsInCloudTest" `
-        --blame-hang-timeout 60s `
+        --blame-hang-timeout 5m `
         --blame-crash `
         -bl:"$testBinLog" `
         --diag "$testDiagLog;TraceLevel=info" `


### PR DESCRIPTION
Tests that create WPF text-input controls can fail during test-host teardown because the mocked UI thread exits before WPF releases its apartment-affine resources. Fixture disposal now lets WPF finish that cleanup on the owning thread. Closing individual test windows no longer ends the shared application lifetime.